### PR TITLE
Get Django version from django.VERSION

### DIFF
--- a/djcelery_ses/urls.py
+++ b/djcelery_ses/urls.py
@@ -2,7 +2,7 @@
 import django
 
 
-if django.get_version() >= '1.9':
+if django.VERSION >= (1, 9):
     from django.conf.urls import url
     from djcelery_ses import views
 


### PR DESCRIPTION
Get Django version from `django.VERSION`.
`django.get_version()` is not working in Django 1.10 since `'1.10 > '1.9'` is `False`.