### PR TITLE
Send multiple messages in one connection

### DIFF
--- a/djcelery_ses/backends.py
+++ b/djcelery_ses/backends.py
@@ -19,13 +19,8 @@ class CeleryEmailBackend(BaseEmailBackend):
         NO_DELAY = getattr(settings, "DJCELERY_SES_NO_DELAY", False)
         CHUNK_SIZE = getattr(settings, "DJCELERY_SES_CHUNK_SIZE", 50)
 
-        pages, remainder = divmod(len(email_messages), CHUNK_SIZE)
-        if remainder != 0:
-            pages += 1
-
-        for page in range(pages):
-            offset = CHUNK_SIZE * page
-            email_messages_chunk = email_messages[offset: offset + CHUNK_SIZE]
+        for index in range(0, len(email_messages), CHUNK_SIZE):
+            email_messages_chunk = email_messages[index: index + CHUNK_SIZE]
 
             if NO_DELAY:
                 send_emails(email_messages_chunk, **kwargs)

--- a/djcelery_ses/tasks.py
+++ b/djcelery_ses/tasks.py
@@ -21,43 +21,51 @@ TASK_CONFIG.update(CONFIG)
 
 
 @task(**TASK_CONFIG)
-def send_email(message, **kwargs):
+def send_emails(messages, **kwargs):
     """
-    send mail task
+    send mails task
     """
-
-    logger = send_email.get_logger()
+    logger = send_emails.get_logger()
     conn = get_connection(backend=BACKEND)
+    conn.open()
 
-    # check blacklist
-    CHECK_BLACKLIST = getattr(settings, 'DJCELERY_SES_CHECK_BLACKLIST', True)
-    if CHECK_BLACKLIST:
-        logger.debug('Check blacklist')
+    num = 0
+    for message in messages:
+        # check blacklist
+        CHECK_BLACKLIST = getattr(
+            settings, 'DJCELERY_SES_CHECK_BLACKLIST', True)
+        if CHECK_BLACKLIST:
+            logger.debug('Check blacklist')
 
-        try:
-            Blacklist.objects.get(email=message.to[0], type=0)
-            logger.debug("Email already in blacklist.")
-            return
-        except Blacklist.DoesNotExist:
-            pass
-
-    # send
-    try:
-        result = conn.send_messages([message])
-        logger.debug("Successfully sent email message to %r.", message.to)
-        MessageLog.objects.log(message, 1)
-        return result
-    except SMTPDataError as e:
-        logger.warning("Message to %r, blacklisted.", message.to)
-        if e.smtp_code == 554:
-            MessageLog.objects.log(message, 3)
             try:
-                Blacklist(email=message.to[0]).save()
-            except IntegrityError:
+                Blacklist.objects.get(email=message.to[0], type=0)
+                logger.debug("Email already in blacklist.")
+                continue
+            except Blacklist.DoesNotExist:
                 pass
-    except Exception as e:
-        MessageLog.objects.log(message, 2)
-        logger.warning("Failed to send email message to %r, retrying.", message.to)
-        send_email.retry(exc=e)
+
+        # send
+        try:
+            result = conn.send_messages([message])
+            logger.debug("Successfully sent email message to %r.", message.to)
+            MessageLog.objects.log(message, 1)
+            num += result
+        except SMTPDataError as e:
+            logger.warning("Message to %r, blacklisted.", message.to)
+            if e.smtp_code == 554:
+                MessageLog.objects.log(message, 3)
+                try:
+                    Blacklist(email=message.to[0]).save()
+                except IntegrityError:
+                    pass
+        except Exception as e:
+            MessageLog.objects.log(message, 2)
+            logger.warning(
+                "Failed to send email message to %r, retrying.", message.to)
+            if len(messages) == 1:
+                send_emails.retry(exc=e)
+            else:
+                send_emails.delay([message], **kwargs)
 
     conn.close()
+    return num


### PR DESCRIPTION
As Django document said, establishing and closing an SMTP connection (or any other network connection, for that matter) is an expensive process. So we should reuse an SMTP connection to send multiple emails, rather than creating and destroying a connection every single email.

This PR change the strategy of sending email. It is no longer sending a task for each email message one by one. It slice the email messages to many of chunks and send a task for each chunk. You can set your own `DJCELERY_SES_CHUNK_SIZE` to control how many email messages you want to send by every single connection.

Because of async tasks, it can only get ids of the tasks, instead of the real result of sending mails. So send_messages will return the length of the argument email_messages.